### PR TITLE
Board name tracking

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## Lockout v0.9.4
+- Completed goals in the goal menu display the player name of the player who completed the goal
+  - Goals with team progression (eat unique foods or breed unique animals) will show player name.
 ## Lockout v0.9.3
 - Fixed spectators getting advancements causing a crash
 

--- a/src/main/java/me/marin/lockout/Lockout.java
+++ b/src/main/java/me/marin/lockout/Lockout.java
@@ -109,12 +109,15 @@ public class Lockout {
 
         LockoutTeamServer team = (LockoutTeamServer) getPlayerTeam(playerId);
 
-        completeGoal(goal, team, team.getPlayerName(playerId) + " completed " + goal.getGoalName() + ".");
+        goal.setCompletedMessage(team.getPlayerName(playerId));
+        completeGoal(goal, team,
+                team.getPlayerName(playerId) + " completed " + goal.getGoalName() + ".", team.getPlayerName(playerId));
     }
     public void completeGoal(Goal goal, LockoutTeam team) {
-        completeGoal(goal, team, team.getDisplayName() + " completed " + goal.getGoalName() + ".");
+        completeGoal(goal, team,
+                team.getDisplayName() + " completed " + goal.getGoalName() + ".", "");
     }
-    public void completeGoal(Goal goal, LockoutTeam team, String message) {
+    public void completeGoal(Goal goal, LockoutTeam team, String message, String goalMessage) {
         if (goal.isCompleted()) return;
         if (!hasStarted()) return;
 
@@ -133,7 +136,7 @@ public class Lockout {
             spectator.sendMessage(Text.literal(message));
         }
 
-        sendGoalCompletedPacket(goal, team);
+        sendGoalCompletedPacket(goal, team, goalMessage);
         evaluateWinnerAndEndGame(team);
     }
 
@@ -167,7 +170,7 @@ public class Lockout {
             spectator.sendMessage(Text.literal(message));
         }
 
-        sendGoalCompletedPacket(goal, winnerTeam);
+        sendGoalCompletedPacket(goal, winnerTeam, "");
         evaluateWinnerAndEndGame(winnerTeam);
     }
 
@@ -182,18 +185,18 @@ public class Lockout {
         if (!goal.isCompleted()) return;
 
         goal.getCompletedTeam().takePoint();
-        goal.setCompleted(false, null);
+        goal.setCompleted(false, null, "");
 
         if (sendPacket) {
-            var payload = new CompleteTaskPayload(goal.getId(), -1);
+            var payload = new CompleteTaskPayload(goal.getId(), -1, "");
             for (ServerPlayerEntity serverPlayer : LockoutServer.server.getPlayerManager().getPlayerList()) {
                 ServerPlayNetworking.send(serverPlayer, payload);
             }
         }
     }
 
-    private void sendGoalCompletedPacket(Goal goal, LockoutTeam team) {
-        var payload = new CompleteTaskPayload(goal.getId(), teams.indexOf(team));
+    private void sendGoalCompletedPacket(Goal goal, LockoutTeam team, String completionMessage) {
+        var payload = new CompleteTaskPayload(goal.getId(), teams.indexOf(team), completionMessage);
         for (ServerPlayerEntity serverPlayer : LockoutServer.server.getPlayerManager().getPlayerList()) {
             ServerPlayNetworking.send(serverPlayer, payload);
         }
@@ -357,5 +360,4 @@ public class Lockout {
             updateGoalCompletion(goal, largestLevelPlayers.get(0));
         }
     }
-
 }

--- a/src/main/java/me/marin/lockout/Utility.java
+++ b/src/main/java/me/marin/lockout/Utility.java
@@ -179,9 +179,17 @@ public class Utility {
         return hoveredIdx.map(integer -> LockoutClient.lockout.getBoard().getGoals().get(integer)).orElse(null);
     }
 
+    // Draws the tooltip text when the player hover over the item slot of a goal in the Board UI
     public static void drawGoalInformation(DrawContext context, TextRenderer textRenderer, Goal goal, int mouseX, int mouseY) {
         List<OrderedText> tooltip = new ArrayList<>();
-        tooltip.add(Text.of(((goal instanceof HasTooltipInfo) ? Formatting.UNDERLINE : "") + goal.getGoalName()).asOrderedText());
+        tooltip.add(Text.of(((goal instanceof HasTooltipInfo) ? Formatting.UNDERLINE : "") + (goal.getGoalName())).asOrderedText());
+
+        // When a goal is completed, display goal completion tooltip
+        if (goal.isCompleted() && !goal.getCompletedMessage().isEmpty())
+        {
+            tooltip.add(Text.of( (Formatting.DARK_GRAY)+ goal.getCompletedMessage()).asOrderedText());
+        }
+
         if (goal instanceof HasTooltipInfo) {
             String s = LockoutClient.goalTooltipMap.get(goal.getId());
             if (s != null) {

--- a/src/main/java/me/marin/lockout/client/LockoutClient.java
+++ b/src/main/java/me/marin/lockout/client/LockoutClient.java
@@ -116,6 +116,7 @@ public class LockoutClient implements ClientModInitializer {
                         }
                     }
                 }
+                goal.setCompletedMessage(payload.completionMessage());
 
 
             });

--- a/src/main/java/me/marin/lockout/lockout/Goal.java
+++ b/src/main/java/me/marin/lockout/lockout/Goal.java
@@ -1,6 +1,7 @@
 package me.marin.lockout.lockout;
 
 import lombok.Getter;
+import lombok.Setter;
 import me.marin.lockout.LockoutTeam;
 import me.marin.lockout.client.LockoutClient;
 import me.marin.lockout.lockout.goals.util.GoalDataConstants;
@@ -10,6 +11,7 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.item.ItemStack;
 
 import java.util.Objects;
+import java.util.UUID;
 
 public abstract class Goal {
 
@@ -20,10 +22,13 @@ public abstract class Goal {
     private boolean isCompleted = false;
     @Getter
     private LockoutTeam completedTeam;
+    @Getter @Setter
+    private String CompletedMessage;
 
     public Goal(String id, String data) {
         this.id = id;
         this.data = data;
+        this.CompletedMessage = "";
     }
 
     public abstract String getGoalName();
@@ -38,6 +43,12 @@ public abstract class Goal {
         this.isCompleted = isCompleted;
         this.completedTeam = team;
     }
+
+    public void setCompleted(boolean isCompleted, LockoutTeam team, String playerName) {
+        setCompleted(isCompleted, team);
+        setCompletedMessage(playerName);
+    }
+
     public boolean isCompleted() {
         return isCompleted;
     }

--- a/src/main/java/me/marin/lockout/lockout/Goal.java
+++ b/src/main/java/me/marin/lockout/lockout/Goal.java
@@ -11,7 +11,6 @@ import net.minecraft.client.gui.DrawContext;
 import net.minecraft.item.ItemStack;
 
 import java.util.Objects;
-import java.util.UUID;
 
 public abstract class Goal {
 

--- a/src/main/java/me/marin/lockout/network/CompleteTaskPayload.java
+++ b/src/main/java/me/marin/lockout/network/CompleteTaskPayload.java
@@ -6,12 +6,15 @@ import net.minecraft.network.codec.PacketCodec;
 import net.minecraft.network.codec.PacketCodecs;
 import net.minecraft.network.packet.CustomPayload;
 
-public record CompleteTaskPayload(String goal, int teamIndex) implements CustomPayload {
+public record CompleteTaskPayload(String goal, int teamIndex, String completionMessage) implements CustomPayload {
     public static final Id<CompleteTaskPayload> ID = new Id<>(Constants.COMPLETE_TASK_PACKET);
-    public static final PacketCodec<RegistryByteBuf, CompleteTaskPayload> CODEC = PacketCodec.tuple(PacketCodecs.STRING,
+    public static final PacketCodec<RegistryByteBuf, CompleteTaskPayload> CODEC = PacketCodec.tuple(
+            PacketCodecs.STRING,
             CompleteTaskPayload::goal,
             PacketCodecs.INTEGER,
             CompleteTaskPayload::teamIndex,
+            PacketCodecs.STRING,
+            CompleteTaskPayload::completionMessage,
             CompleteTaskPayload::new);
 
     @Override


### PR DESCRIPTION
Completed goals track when player completed the goal given the goal has team-wide progression (i.e. Breed 4 unique animals). In the board menu, when the completed goal is hovered, the player name will display in the tooltip under the goal's name.
<img width="854" height="480" alt="image" src="https://github.com/user-attachments/assets/59d000f8-c3cd-4969-b160-495d407d2553" />
