### PR TITLE
Goal: Kill player with named item

### DIFF
--- a/src/main/java/me/marin/lockout/lockout/DefaultGoalRegister.java
+++ b/src/main/java/me/marin/lockout/lockout/DefaultGoalRegister.java
@@ -334,6 +334,8 @@ public class DefaultGoalRegister {
         INSTANCE.register(GoalType.WEAR_UNIQUE_COLORED_LEATHER_ARMOR, WearUniqueColoredLeatherArmorGoal.class);
         INSTANCE.register(GoalType.KILL_OTHER_PLAYER, KillOtherTeamPlayer.class,
                 GoalRequirements.TEAMS_GOAL);
+        INSTANCE.register(GoalType.KILL_OTHER_PLAYER_WITH_NAMED_ITEM, KillOtherTeamPlayerWithNamedItem.class,
+                GoalRequirements.TEAMS_GOAL);
         INSTANCE.register(GoalType.OPPONENT_OBTAINS_CRAFTING_TABLE, OpponentObtainsCraftingTableGoal.class,
                 GoalRequirements.TO2_ONLY_GOAL_NOT_IN_RANDOM_POOL);
         INSTANCE.register(GoalType.OPPONENT_OBTAINS_OBSIDIAN, OpponentObtainsObsidianGoal.class,

--- a/src/main/java/me/marin/lockout/lockout/GoalType.java
+++ b/src/main/java/me/marin/lockout/lockout/GoalType.java
@@ -197,6 +197,7 @@ public class GoalType {
     public static final String GET_30_ADVANCEMENTS = "GET_30_ADVANCEMENTS";
     public static final String WEAR_UNIQUE_COLORED_LEATHER_ARMOR = "WEAR_UNIQUE_COLORED_LEATHER_ARMOR";
     public static final String KILL_OTHER_PLAYER = "KILL_OTHER_PLAYER";
+    public static final String KILL_OTHER_PLAYER_WITH_NAMED_ITEM = "KILL_OTHER_PLAYER_WITH_NAMED_ITEM";
     public static final String TAKE_200_DAMAGE = "TAKE_200_DAMAGE";
     public static final String OPPONENT_OBTAINS_CRAFTING_TABLE = "OPPONENT_OBTAINS_CRAFTING_TABLE";
     public static final String OPPONENT_OBTAINS_OBSIDIAN = "OPPONENT_OBTAINS_OBSIDIAN";

--- a/src/main/java/me/marin/lockout/lockout/goals/kill/KillOtherTeamPlayerWithNamedItem.java
+++ b/src/main/java/me/marin/lockout/lockout/goals/kill/KillOtherTeamPlayerWithNamedItem.java
@@ -1,0 +1,31 @@
+package me.marin.lockout.lockout.goals.kill;
+
+import me.marin.lockout.Constants;
+import me.marin.lockout.lockout.Goal;
+import me.marin.lockout.lockout.texture.TextureProvider;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.Identifier;
+
+public class KillOtherTeamPlayerWithNamedItem extends Goal implements TextureProvider {
+
+    public KillOtherTeamPlayerWithNamedItem(String id, String data) {
+        super(id, data);
+    }
+
+    @Override
+    public String getGoalName() {
+        return "Kill another team's player with a named item";
+    }
+
+    @Override
+    public ItemStack getTextureItemStack() {
+        return null;
+    }
+
+    private static final Identifier TEXTURE = Identifier.of(Constants.NAMESPACE, "textures/custom/kill_player.png");
+    @Override
+    public Identifier getTextureIdentifier() {
+        return TEXTURE;
+    }
+
+}

--- a/src/main/java/me/marin/lockout/server/handlers/AfterDeathEventHandler.java
+++ b/src/main/java/me/marin/lockout/server/handlers/AfterDeathEventHandler.java
@@ -23,6 +23,7 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.vehicle.TntMinecartEntity;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.server.world.ServerWorld;
 
@@ -188,7 +189,8 @@ public class AfterDeathEventHandler implements ServerLivingEntityEvents.AfterDea
 
                     if (!Objects.equals(player, killer) &&
                             !Objects.equals(lockout.getPlayerTeam(killer.getUuid()), lockout.getPlayerTeam(player.getUuid())) &&
-                            item != null && heldItem.contains(DataComponentTypes.CUSTOM_NAME)) {
+                            item != null && heldItem.contains(DataComponentTypes.CUSTOM_NAME) &&
+                            !heldItem.isOf(Items.COMPASS)) {
                         lockout.completeGoal(goal, killer);
                     }
                 }

--- a/src/main/java/me/marin/lockout/server/handlers/AfterDeathEventHandler.java
+++ b/src/main/java/me/marin/lockout/server/handlers/AfterDeathEventHandler.java
@@ -11,6 +11,7 @@ import me.marin.lockout.lockout.goals.opponent.OpponentDies3TimesGoal;
 import me.marin.lockout.lockout.goals.opponent.OpponentDiesGoal;
 import me.marin.lockout.lockout.interfaces.*;
 import net.fabricmc.fabric.api.entity.event.v1.ServerLivingEntityEvents;
+import net.minecraft.component.DataComponentTypes;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.damage.DamageType;
@@ -20,6 +21,8 @@ import net.minecraft.entity.mob.Monster;
 import net.minecraft.entity.passive.SheepEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.vehicle.TntMinecartEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import net.minecraft.registry.RegistryKey;
 import net.minecraft.server.world.ServerWorld;
 
@@ -174,6 +177,18 @@ public class AfterDeathEventHandler implements ServerLivingEntityEvents.AfterDea
                     PlayerEntity killer = (PlayerEntity) entity.getPrimeAdversary();
 
                     if (!Objects.equals(player, killer) && !Objects.equals(lockout.getPlayerTeam(killer.getUuid()), lockout.getPlayerTeam(player.getUuid()))) {
+                        lockout.completeGoal(goal, killer);
+                    }
+                }
+
+                if (goal instanceof KillOtherTeamPlayerWithNamedItem && killedByPlayer) {
+                    PlayerEntity killer = (PlayerEntity) entity.getPrimeAdversary();
+                    ItemStack heldItem = killer.getMainHandStack();
+                    Item item = heldItem.getItem();
+
+                    if (!Objects.equals(player, killer) &&
+                            !Objects.equals(lockout.getPlayerTeam(killer.getUuid()), lockout.getPlayerTeam(player.getUuid())) &&
+                            item != null && heldItem.contains(DataComponentTypes.CUSTOM_NAME)) {
                         lockout.completeGoal(goal, killer);
                     }
                 }


### PR DESCRIPTION
Add goal: Kill another team's player with a named item.
- This excludes compasses to prevent early pvp with the player tracker compass.