### PR TITLE
Red square goal completion thing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 - Added feature that when F3 is pressed when board position is set to Left it moves to right until user pesses F3 again, then it moves abck to left
 - Fixed bug where completed goal highlights would bleed into adjacent slot borders, causing them to merge into a solid block
 - Fixed bug where the lockout settings button would appear in the F3+ESC game menu
+- Fixed bug where using F3 combo shortcuts (e.g. F3+B for hitboxes) would incorrectly move the board to the right
+- Fixed bug where status effects overlay would not account for board scale, causing overlap at larger board sizes
 ## Lockout v0.11.8
 - Fixed bug where blackout timer would multiply the amount of time that the timer went up/ down by when the user did not close their instance between worlds
 - Added feature to allow the user to toggle the board on/ off, default button H (User can change in keybinds)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 - Added move board location Left and Right on this screen
 - Added keybinds for Open Board, Open Pick/ Ban list, toggle board visibility, toggle section view, next section, toggle auto-cycle sections to lockout settings page
 - Added feature that when F3 is pressed when board position is set to Left it moves to right until user pesses F3 again, then it moves abck to left
+- Fixed bug where completed goal highlights would bleed into adjacent slot borders, causing them to merge into a solid block
+- Fixed bug where the lockout settings button would appear in the F3+ESC game menu
 ## Lockout v0.11.8
 - Fixed bug where blackout timer would multiply the amount of time that the timer went up/ down by when the user did not close their instance between worlds
 - Added feature to allow the user to toggle the board on/ off, default button H (User can change in keybinds)

--- a/src/main/java/me/marin/lockout/Utility.java
+++ b/src/main/java/me/marin/lockout/Utility.java
@@ -27,7 +27,7 @@ public class Utility {
 
     public static int FF000000 = 0xFF000000;
 
-    private static float getSafeBoardScale() {
+    public static float getSafeBoardScale() {
         double boardScale = LockoutConfig.getInstance().boardScale;
         if (!Double.isFinite(boardScale)) {
             return 1.0F;
@@ -41,8 +41,8 @@ public class Utility {
             boardPosition = LockoutConfig.BoardPosition.RIGHT;
         }
 
-        // When F3 is open, left side is occupied by debug info. Render on the right instead of hiding.
-        if (boardPosition == LockoutConfig.BoardPosition.LEFT && MinecraftClient.getInstance().inGameHud.getDebugHud().shouldShowDebugHud()) {
+        // Move board right when the user has intentionally opened the debug menu (pure F3, no combo).
+        if (boardPosition == LockoutConfig.BoardPosition.LEFT && LockoutClient.lockoutDebugHudOpen) {
             return LockoutConfig.BoardPosition.RIGHT;
         }
 

--- a/src/main/java/me/marin/lockout/Utility.java
+++ b/src/main/java/me/marin/lockout/Utility.java
@@ -89,7 +89,7 @@ public class Utility {
                 Goal goal = board.getGoals().get(j + board.size() * i);
                 if (goal != null) {
                     if (goal.isCompleted()) {
-                        context.fill(x, y, x + GUI_SLOT_SIZE, y + GUI_SLOT_SIZE, FF000000 | goal.getCompletedTeam().getColor().getColorValue());
+                        context.fill(x, y, x + 16, y + 16, FF000000 | goal.getCompletedTeam().getColor().getColorValue());
                     }
 
                     goal.render(context, textRenderer, x, y);
@@ -196,7 +196,7 @@ public class Utility {
                 Goal goal = board.getGoals().get(j + boardSize * i);
                 if (goal != null) {
                     if (goal.isCompleted()) {
-                        context.fill(x, y, x + GUI_SLOT_SIZE, y + GUI_SLOT_SIZE, FF000000 | goal.getCompletedTeam().getColor().getColorValue());
+                        context.fill(x, y, x + 16, y + 16, FF000000 | goal.getCompletedTeam().getColor().getColorValue());
                     }
 
                     goal.render(context, textRenderer, x, y);
@@ -290,13 +290,13 @@ public class Utility {
                 Goal goal = board.getGoals().get(j + board.size() * i);
                 if (goal != null) {
                     if (goal.isCompleted()) {
-                        context.fill(x, y, x + GUI_CENTER_SLOT_SIZE, y + GUI_CENTER_SLOT_SIZE, (0xFF << 24) | goal.getCompletedTeam().getColor().getColorValue());
+                        context.fill(x, y, x + 16, y + 16, (0xFF << 24) | goal.getCompletedTeam().getColor().getColorValue());
                     }
 
                     goal.render(context, textRenderer, x, y);
 
                     if (goal == hoveredGoal) {
-                        context.fill(x, y, x + GUI_CENTER_SLOT_SIZE, y + GUI_CENTER_SLOT_SIZE, GUI_CENTER_HOVERED_COLOR);
+                        context.fill(x, y, x + 16, y + 16, GUI_CENTER_HOVERED_COLOR);
                     }
                 }
                 x += GUI_CENTER_SLOT_SIZE;

--- a/src/main/java/me/marin/lockout/client/LockoutClient.java
+++ b/src/main/java/me/marin/lockout/client/LockoutClient.java
@@ -59,6 +59,7 @@ public class LockoutClient implements ClientModInitializer {
     private static KeyBinding nextSectionKeyBinding;
     private static KeyBinding toggleAutoCycleSectionKeyBinding;
     public static boolean boardVisible = true;
+    public static boolean lockoutDebugHudOpen = false;  // mirrors debug HUD open state, updated only on pure F3 (no combo)
     public static boolean sectionViewEnabled = false;
     public static int currentSection = 1;  // 1-4, which section to display
     public static boolean autoCycleSectionEnabled = false;

--- a/src/main/java/me/marin/lockout/mixin/client/InGameHudMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/client/InGameHudMixin.java
@@ -42,11 +42,13 @@ public abstract class InGameHudMixin {
             return width;
         }
 
-        if (LockoutConfig.getInstance().boardPosition != LockoutConfig.BoardPosition.RIGHT) {
+        if (Utility.getEffectiveBoardPosition() != LockoutConfig.BoardPosition.RIGHT) {
             return width;
         }
 
-        return width - 2 * GUI_PADDING - LockoutClient.lockout.getBoard().size() * GUI_SLOT_SIZE;
+        float boardScale = Utility.getSafeBoardScale();
+        int scaledBoardWidth = Math.max(1, Math.round((2 * GUI_PADDING + LockoutClient.lockout.getBoard().size() * GUI_SLOT_SIZE) * boardScale));
+        return width - scaledBoardWidth;
     }
 
 }

--- a/src/main/java/me/marin/lockout/mixin/client/KeyboardMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/client/KeyboardMixin.java
@@ -1,0 +1,44 @@
+package me.marin.lockout.mixin.client;
+
+import me.marin.lockout.client.LockoutClient;
+import net.minecraft.client.Keyboard;
+import net.minecraft.client.input.KeyInput;
+import org.lwjgl.glfw.GLFW;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Keyboard.class)
+public class KeyboardMixin {
+
+    @Unique
+    private boolean lockout$f3Held = false;
+    @Unique
+    private boolean lockout$f3ComboUsed = false;
+
+    /**
+     * On pure F3 release (no combo key pressed while F3 was held), toggle our own
+     * lockoutDebugHudOpen flag. This mirrors what Minecraft does internally with
+     * switchF3State, without reading shouldShowDebugHud() which can be unreliable
+     * when keys are pressed in rapid succession.
+     */
+    @Inject(method = "onKey", at = @At("HEAD"))
+    private void lockout$onKey(long window, int action, KeyInput input, CallbackInfo ci) {
+        if (input.key() == GLFW.GLFW_KEY_F3) {
+            if (action == GLFW.GLFW_PRESS) {
+                lockout$f3Held = true;
+                lockout$f3ComboUsed = false;
+            } else if (action == GLFW.GLFW_RELEASE) {
+                if (!lockout$f3ComboUsed) {
+                    LockoutClient.lockoutDebugHudOpen = !LockoutClient.lockoutDebugHudOpen;
+                }
+                lockout$f3Held = false;
+                lockout$f3ComboUsed = false;
+            }
+        } else if (action == GLFW.GLFW_PRESS && lockout$f3Held) {
+            lockout$f3ComboUsed = true;
+        }
+    }
+}

--- a/src/main/java/me/marin/lockout/mixin/client/PauseScreenMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/client/PauseScreenMixin.java
@@ -12,6 +12,7 @@ import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.text.Text;
 import net.minecraft.util.Identifier;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,6 +23,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
  */
 @Mixin(GameMenuScreen.class)
 public class PauseScreenMixin extends Screen {
+
+    @Shadow
+    private boolean showMenu;
 
     @Unique
     private static final Identifier LOCK_ICON_TEXTURE = Identifier.of(Constants.NAMESPACE, "textures/gui/sprites/lock.png");
@@ -41,6 +45,8 @@ public class PauseScreenMixin extends Screen {
         at = @At("TAIL")
     )
     private void lockout$addLockoutSettingsButton(CallbackInfo ci) {
+        if (!showMenu) return;
+
         MinecraftClient client = MinecraftClient.getInstance();
 
         int buttonX = this.width / 2 - 126;

--- a/src/main/resources/Lockout.mixins.json
+++ b/src/main/resources/Lockout.mixins.json
@@ -65,6 +65,7 @@
     "client.toasts.RecipeToastMixin",
     "client.toasts.SystemToastMixin",
     "client.toasts.TutorialToastMixin",
+    "client.KeyboardMixin",
     "client.LocatorBarMixin",
     "client.PauseScreenMixin",
     "client.WorldRendererMixin"


### PR DESCRIPTION
Fixed bug where completed goal highlights would bleed into adjacent slot borders, causing them to merge into a solid block
Fixed bug where the lockout settings button would appear in the F3+ESC game menu