### PR TITLE
Flip flop goal fix

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - Added Post Game Statistics
 	- Can be viewed ingame or downloaded
 - Reworked how Time Based Goals are Calculated and Displayed
+- Fixed issue where tooltips for "Have More" goals were only updated on Leader change
 ## Lockout v0.11.9
 - Added lockout settings page with lockout symbol next to the options button in the pause menu
 - Added Board scale from 0.5x to 2.0x

--- a/src/main/java/me/marin/lockout/mixin/server/CraftingResultSlotMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/server/CraftingResultSlotMixin.java
@@ -44,6 +44,7 @@ public class CraftingResultSlotMixin {
         if (player.getEntityWorld().isClient()) return;
         Lockout lockout = LockoutServer.lockout;
         if (!Lockout.isLockoutRunning(lockout)) return;
+        if (!lockout.isLockoutPlayer(player.getUuid())) return;
 
         if (amount < 0 || stack.isEmpty()) {
             return;
@@ -89,10 +90,10 @@ public class CraftingResultSlotMixin {
 
                     lockout.mostUniqueCraftsPlayer = player.getUuid();
                     lockout.mostUniqueCrafts = crafts.size();
-                    // Send tooltip updates to all teams
-                    for (LockoutTeam teamToUpdate : lockout.getTeams()) {
-                        ((LockoutTeamServer) teamToUpdate).sendTooltipUpdate((HaveMostUniqueCraftsGoal) goal, true);
-                    }
+                }
+                // Send tooltip updates to all teams whenever anyone makes progress
+                for (LockoutTeam teamToUpdate : lockout.getTeams()) {
+                    ((LockoutTeamServer) teamToUpdate).sendTooltipUpdate((HaveMostUniqueCraftsGoal) goal, true);
                 }
             }
         }

--- a/src/main/java/me/marin/lockout/mixin/server/PlayerAdvancementTrackerMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/server/PlayerAdvancementTrackerMixin.java
@@ -101,10 +101,10 @@ public abstract class PlayerAdvancementTrackerMixin {
                         }
                         lockout.mostAdvancementsPlayer = owner.getUuid();
                         lockout.mostAdvancements = playerAdvancements;
-                        // Send tooltip updates to all teams
-                        for (LockoutTeam teamToUpdate : lockout.getTeams()) {
-                            ((LockoutTeamServer) teamToUpdate).sendTooltipUpdate((HaveMostAdvancementsGoal) goal, true);
-                        }
+                    }
+                    // Send tooltip updates to all teams whenever anyone makes progress
+                    for (LockoutTeam teamToUpdate : lockout.getTeams()) {
+                        ((LockoutTeamServer) teamToUpdate).sendTooltipUpdate((HaveMostAdvancementsGoal) goal, true);
                     }
                 }
             }

--- a/src/main/java/me/marin/lockout/mixin/server/SlotMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/server/SlotMixin.java
@@ -44,6 +44,7 @@ public class SlotMixin {
         if (player.getEntityWorld().isClient()) return;
         Lockout lockout = LockoutServer.lockout;
         if (!Lockout.isLockoutRunning(lockout)) return;
+        if (!lockout.isLockoutPlayer(player.getUuid())) return;
 
         Slot slot = (Slot) (Object) this;
 
@@ -89,10 +90,10 @@ public class SlotMixin {
 
                                         lockout.mostUniqueSmeltsPlayer = serverPlayer.getUuid();
                                         lockout.mostUniqueSmelts = smelts.size();
-                                        // Send tooltip updates to all teams
-                                        for (LockoutTeam teamToUpdate : lockout.getTeams()) {
-                                            ((LockoutTeamServer) teamToUpdate).sendTooltipUpdate((HaveMostUniqueSmeltsGoal) goal, true);
-                                        }
+                                    }
+                                    // Send tooltip updates to all teams whenever anyone makes progress
+                                    for (LockoutTeam teamToUpdate : lockout.getTeams()) {
+                                        ((LockoutTeamServer) teamToUpdate).sendTooltipUpdate((HaveMostUniqueSmeltsGoal) goal, true);
                                     }
                                 }
                             }

--- a/src/main/java/me/marin/lockout/server/handlers/AfterDeathEventHandler.java
+++ b/src/main/java/me/marin/lockout/server/handlers/AfterDeathEventHandler.java
@@ -50,19 +50,39 @@ public class AfterDeathEventHandler implements ServerLivingEntityEvents.AfterDea
             lockout.deaths.putIfAbsent(team, 0);
             lockout.deaths.merge(team, 1, Integer::sum);
             
-            // Track this death for statistics (we'll check if it's a task death later)
+            // Track this death for statistics - only mark as task death if it actually completes a death goal
             boolean isTaskDeath = false;
             
-            // Check if this death is for a task/goal
+            // Check if this death actually completes a death-related goal
             for (Goal goal : lockout.getBoard().getGoals()) {
                 if (goal == null || goal.isCompleted()) continue;
                 
-                // Check if this is a death-related goal
-                if (goal instanceof DieToDamageTypeGoal || goal instanceof DieToEntityGoal || 
-                    goal instanceof DieToFallingOffVinesGoal || goal instanceof DieToTNTMinecartGoal) {
-                    isTaskDeath = true;
-                    break;
+                // Check if this specific death matches and would complete a death goal
+                if (goal instanceof DieToDamageTypeGoal dieToDamageTypeGoal) {
+                    for (RegistryKey<DamageType> key : dieToDamageTypeGoal.getDamageRegistryKeys()) {
+                        if (source.getTypeRegistryEntry().matchesKey(key)) {
+                            isTaskDeath = true;
+                            break;
+                        }
+                    }
+                } else if (goal instanceof DieToEntityGoal dieToEntityGoal) {
+                    if (source.getAttacker() != null && source.getAttacker().getType() == dieToEntityGoal.getEntityType()) {
+                        isTaskDeath = true;
+                    }
+                } else if (goal instanceof DieToFallingOffVinesGoal) {
+                    if (source.getTypeRegistryEntry().matchesKey(DamageTypes.FALL)) {
+                        FallLocation fallLocation = FallLocation.fromEntity((PlayerEntity) entity);
+                        if (fallLocation != null && List.of(FallLocation.VINES, FallLocation.TWISTING_VINES, FallLocation.WEEPING_VINES).contains(fallLocation)) {
+                            isTaskDeath = true;
+                        }
+                    }
+                } else if (goal instanceof DieToTNTMinecartGoal) {
+                    if (source.getSource() instanceof TntMinecartEntity) {
+                        isTaskDeath = true;
+                    }
                 }
+                
+                if (isTaskDeath) break;
             }
             
             // Record death in statistics
@@ -83,12 +103,18 @@ public class AfterDeathEventHandler implements ServerLivingEntityEvents.AfterDea
             }
         }
         
-        // Track player kills for statistics
+        // Track player kills for statistics (only PvP between different teams)
         if (playerDied && killedByPlayer) {
             PlayerEntity killer = (PlayerEntity) entity.getPrimeAdversary();
-            if (lockout.isLockoutPlayer(killer.getUuid())) {
-                if (lockout.getStatistics() != null) {
-                    lockout.getStatistics().recordPlayerKill(killer.getUuid());
+            PlayerEntity victim = (PlayerEntity) entity;
+            if (lockout.isLockoutPlayer(killer.getUuid()) && lockout.isLockoutPlayer(victim.getUuid())) {
+                // Only count as player kill if they're on different teams
+                LockoutTeam killerTeam = lockout.getPlayerTeam(killer.getUuid());
+                LockoutTeam victimTeam = lockout.getPlayerTeam(victim.getUuid());
+                if (!Objects.equals(killerTeam, victimTeam)) {
+                    if (lockout.getStatistics() != null) {
+                        lockout.getStatistics().recordPlayerKill(killer.getUuid());
+                    }
                 }
             }
         }

--- a/src/main/java/me/marin/lockout/server/handlers/EndServerTickEventHandler.java
+++ b/src/main/java/me/marin/lockout/server/handlers/EndServerTickEventHandler.java
@@ -60,7 +60,10 @@ public class EndServerTickEventHandler implements ServerTickEvents.EndTick {
 
             if (goal instanceof HaveMostXPLevelsGoal) {
                 for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
-                    lockout.levels.put(player.getUuid(), player.isDead() ? 0 : player.experienceLevel);
+                    // Only track lockout players, not spectators
+                    if (lockout.isLockoutPlayer(player.getUuid())) {
+                        lockout.levels.put(player.getUuid(), player.isDead() ? 0 : player.experienceLevel);
+                    }
                 }
                 lockout.recalculateXPGoal(goal);
                 // Send tooltip updates to all teams
@@ -71,8 +74,11 @@ public class EndServerTickEventHandler implements ServerTickEvents.EndTick {
 
             if (goal instanceof HaveMostCreeperKillsGoal) {
                 for (ServerPlayerEntity player : server.getPlayerManager().getPlayerList()) {
-                    int creeperKills = player.getStatHandler().getStat(net.minecraft.stat.Stats.KILLED.getOrCreateStat(net.minecraft.entity.EntityType.CREEPER));
-                    lockout.creeperKills.put(player.getUuid(), creeperKills);
+                    // Only track lockout players, not spectators
+                    if (lockout.isLockoutPlayer(player.getUuid())) {
+                        int creeperKills = player.getStatHandler().getStat(net.minecraft.stat.Stats.KILLED.getOrCreateStat(net.minecraft.entity.EntityType.CREEPER));
+                        lockout.creeperKills.put(player.getUuid(), creeperKills);
+                    }
                 }
                 lockout.recalculateCreeperKillsGoal(goal);
                 // Send tooltip updates to all teams

--- a/src/main/java/me/marin/lockout/statistics/LockoutStatistics.java
+++ b/src/main/java/me/marin/lockout/statistics/LockoutStatistics.java
@@ -6,8 +6,11 @@ import me.marin.lockout.LockoutTeam;
 import me.marin.lockout.LockoutTeamServer;
 import me.marin.lockout.lockout.Goal;
 import me.marin.lockout.lockout.interfaces.*;
+import me.marin.lockout.lockout.goals.have_more.HaveMostAdvancementsGoal;
+import me.marin.lockout.lockout.goals.have_more.HaveMostCreeperKillsGoal;
 import me.marin.lockout.lockout.goals.have_more.HaveMostUniqueCraftsGoal;
 import me.marin.lockout.lockout.goals.have_more.HaveMostUniqueSmeltsGoal;
+import me.marin.lockout.lockout.goals.have_more.HaveMostXPLevelsGoal;
 import me.marin.lockout.lockout.goals.opponent.*;
 import me.marin.lockout.lockout.goals.wear_armor.WearCarvedPumpkinFor5MinutesGoal;
 import me.marin.lockout.lockout.goals.misc.*;
@@ -214,125 +217,126 @@ public class LockoutStatistics {
         
         // Check for goals with individual player tracking
         
+        // "Have More" goals - only the leader gets 1.0 contribution, everyone else gets 0.0
+        if (goal instanceof HaveMostXPLevelsGoal) {
+            UUID leader = lockout.mostLevelsPlayer;
+            if (leader != null && teamPlayers.contains(leader)) {
+                contributions.put(leader, 1.0);
+            }
+            return contributions;
+        }
+        
+        if (goal instanceof HaveMostCreeperKillsGoal) {
+            UUID leader = lockout.mostCreeperKillsPlayer;
+            if (leader != null && teamPlayers.contains(leader)) {
+                contributions.put(leader, 1.0);
+            }
+            return contributions;
+        }
+        
+        if (goal instanceof HaveMostAdvancementsGoal) {
+            UUID leader = lockout.mostAdvancementsPlayer;
+            if (leader != null && teamPlayers.contains(leader)) {
+                contributions.put(leader, 1.0);
+            }
+            return contributions;
+        }
+        
+        if (goal instanceof HaveMostUniqueCraftsGoal) {
+            UUID leader = lockout.mostUniqueCraftsPlayer;
+            if (leader != null && teamPlayers.contains(leader)) {
+                contributions.put(leader, 1.0);
+            }
+            return contributions;
+        }
+        
+        if (goal instanceof HaveMostUniqueSmeltsGoal) {
+            UUID leader = lockout.mostUniqueSmeltsPlayer;
+            if (leader != null && teamPlayers.contains(leader)) {
+                contributions.put(leader, 1.0);
+            }
+            return contributions;
+        }
+        
         // 1. Advancement-based goals - use playerUniqueAdvancements with first contributor tracking
         if (goal instanceof GetUniqueAdvancementsGoal) {
             Map<Identifier, UUID> firstContributor = lockout.firstAdvancementContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerUniqueAdvancements, firstContributor);
         }
         
-        // 2. Craft-based goals - use uniqueCrafts size
-        if (goal instanceof HaveMostUniqueCraftsGoal) {
-            int totalCrafts = 0;
-            Map<UUID, Integer> playerCounts = new HashMap<>();
-            
-            for (UUID playerId : teamPlayers) {
-                int count = lockout.uniqueCrafts.getOrDefault(playerId, new HashSet<>()).size();
-                playerCounts.put(playerId, count);
-                totalCrafts += count;
-            }
-            
-            if (totalCrafts > 0) {
-                for (UUID playerId : teamPlayers) {
-                    double contribution = (double) playerCounts.get(playerId) / totalCrafts;
-                    contributions.put(playerId, contribution);
-                }
-                return contributions;
-            }
-        }
-        
-        // 3. Smelt-based goals - use uniqueSmelts size
-        if (goal instanceof HaveMostUniqueSmeltsGoal) {
-            int totalSmelts = 0;
-            Map<UUID, Integer> playerCounts = new HashMap<>();
-            
-            for (UUID playerId : teamPlayers) {
-                int count = lockout.uniqueSmelts.getOrDefault(playerId, new HashSet<>()).size();
-                playerCounts.put(playerId, count);
-                totalSmelts += count;
-            }
-            
-            if (totalSmelts > 0) {
-                for (UUID playerId : teamPlayers) {
-                    double contribution = (double) playerCounts.get(playerId) / totalSmelts;
-                    contributions.put(playerId, contribution);
-                }
-                return contributions;
-            }
-        }
-        
-        // 4. Food-based goals - use playerFoodsEaten size
+        // 2. Food-based goals - use playerFoodsEaten size
         if (goal instanceof EatUniqueFoodsGoal) {
             Map<Item, UUID> firstContributor = lockout.firstFoodContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerFoodsEaten, firstContributor);
         }
         
-        // 5. Biome visiting goals
+        // 3. Biome visiting goals
         if (goal instanceof VisitUniqueBiomesGoal || goal instanceof VisitAllSpecificBiomesGoal) {
             Map<Identifier, UUID> firstContributor = lockout.firstBiomeContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerBiomesVisited, firstContributor);
         }
         
-        // 6. Breeding animals goals
+        // 4. Breeding animals goals
         if (goal instanceof BreedUniqueAnimalsGoal) {
             Map<EntityType<?>, UUID> firstContributor = lockout.firstBredAnimalContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerBredAnimals, firstContributor);
         }
         
-        // 7. Looking at mobs goals
+        // 5. Looking at mobs goals
         if (goal instanceof LookAtUniqueMobsGoal) {
             Map<EntityType<?>, UUID> firstContributor = lockout.firstLookedAtMobContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerLookedAtMobs, firstContributor);
         }
         
-        // 8. Killing hostile mobs goals
+        // 6. Killing hostile mobs goals
         if (goal instanceof KillUniqueHostileMobsGoal) {
             Map<EntityType<?>, UUID> firstContributor = lockout.firstHostileKillContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerKilledHostileMobs, firstContributor);
         }
         
-        // 9. Killing arthropods goal
+        // 7. Killing arthropods goal
         if (goal.getGoalName().contains("Arthropod")) {
             return calculateProportionalContributionFromInt(teamPlayers, lockout.playerKilledArthropods);
         }
         
-        // 10. Killing undead mobs goal
+        // 8. Killing undead mobs goal
         if (goal.getGoalName().contains("Undead Mobs")) {
             return calculateProportionalContributionFromInt(teamPlayers, lockout.playerKilledUndeadMobs);
         }
         
-        // 11. Kill 100 Mobs goal
+        // 9. Kill 100 Mobs goal
         if (goal.getGoalName().equals("Kill 100 Mobs")) {
             return calculateProportionalContributionFromInt(teamPlayers, lockout.playerMobsKilled);
         }
         
-        // 12. Pumpkin wearing goal (5 minutes = 6000 ticks)
+        // 10. Pumpkin wearing goal (5 minutes = 6000 ticks)
         if (goal instanceof WearCarvedPumpkinFor5MinutesGoal) {
             return calculateProportionalContributionFromTime(teamPlayers, lockout.pumpkinWearTime, 5 * 60 * 20L);
         }
         
-        // 13. Effects applied goal  
+        // 11. Effects applied goal  
         if (goal instanceof HaveEffectsAppliedForXMinutesGoal effectsGoal) {
             long requiredTicks = effectsGoal.getMinutes() * 60 * 20L;
             return calculateProportionalContributionFromTime(teamPlayers, lockout.appliedEffectsTime, requiredTicks);
         }
         
-        // 14. Damage taken goal
+        // 12. Damage taken goal
         if (goal instanceof Take200DamageGoal) {
             return calculateProportionalContributionFromDouble(teamPlayers, lockout.playerDamageTaken);
         }
         
-        // 15. Damage dealt goal
+        // 13. Damage dealt goal
         if (goal instanceof Deal400DamageGoal) {
             return calculateProportionalContributionFromDouble(teamPlayers, lockout.playerDamageDealt);
         }
         
-        // 16. Damage types taken goal
+        // 14. Damage types taken goal
         if (goal instanceof DamagedByUniqueSourcesGoal) {
             Map<RegistryKey<DamageType>, UUID> firstContributor = lockout.firstDamageTypeContributor.get(team);
             return calculateProportionalContribution(teamPlayers, lockout.playerDamageTypesTaken, firstContributor);
         }
         
-        // 17. Opponent goals - each player on winning team gets 0.5
+        // 15. Opponent goals - each player on winning team gets 0.5
         if (isOpponentGoalWithEqualCredit(goal)) {
             for (UUID playerId : teamPlayers) {
                 contributions.put(playerId, 0.5);
@@ -340,7 +344,7 @@ public class LockoutStatistics {
             return contributions;
         }
         
-        // 18. For other goals, check completedMessage for single contributor
+        // 16. For other goals, check completedMessage for single contributor
         String completedMessage = goal.getCompletedMessage();
         if (completedMessage != null && !completedMessage.isEmpty()) {
             boolean foundPlayer = false;


### PR DESCRIPTION
- fixed issue with flipflip goals only updating on leader change
- fixed goal contribution for flip flop goals
- fixed death statistics not increasing when a death task was on the board
- fixed issue where players would get a PvP kill statistic when killing themselves or a teammate