### PR TITLE
Fix NPE crash in Enderman and ZombifiedPiglin mixins

### DIFF
--- a/src/main/java/me/marin/lockout/mixin/server/EndermanEntityMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/server/EndermanEntityMixin.java
@@ -20,7 +20,7 @@ public class EndermanEntityMixin {
     @Inject(method = "setAngryAt", at = @At("HEAD"))
     public void setAngryAt(@Nullable LazyEntityReference<LivingEntity> angryAt, CallbackInfo ci) {
         EndermanEntity enderman = (EndermanEntity) (Object) this;
-        if (enderman.getEntityWorld().isClient()) return;
+        if (angryAt == null || enderman.getEntityWorld().isClient()) return;
 
         Lockout lockout = LockoutServer.lockout;
         if (!Lockout.isLockoutRunning(lockout)) {

--- a/src/main/java/me/marin/lockout/mixin/server/ZombifiedPiglinEntityMixin.java
+++ b/src/main/java/me/marin/lockout/mixin/server/ZombifiedPiglinEntityMixin.java
@@ -23,7 +23,7 @@ public class ZombifiedPiglinEntityMixin {
     @Inject(method = "setAngryAt", at = @At("HEAD"))
     public void setAngryAt(@Nullable LazyEntityReference<LivingEntity> angryAt, CallbackInfo ci) {
         ZombifiedPiglinEntity pigman = (ZombifiedPiglinEntity) (Object) this;
-        if (pigman.getEntityWorld().isClient()) return;
+        if (angryAt == null || pigman.getEntityWorld().isClient()) return;
 
         Lockout lockout = LockoutServer.lockout;
         if (!Lockout.isLockoutRunning(lockout)) {


### PR DESCRIPTION
The Issue:

Loading Enderman and ZombifiedPiglin entities resulted in a server crash when checking for the ENRAGE_ENDERMAN and ENRAGE_ZOMBIFIED_PIGLIN goals. The crash is caused by a NullPointerException when angryAt is null.


Crash Logs:

```text
[Server thread/INFO]: [STDERR]: java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.EntityReference.getEntity(net.minecraft.world.level.Level, java.lang.Class)" because "angryAt" is null
[Server thread/INFO]: [STDERR]:      at knot//net.minecraft.world.entity.monster.EnderMan.handler$bhe000$lockout$setAngryAt(EnderMan.java:532)
[Server thread/INFO]: [STDERR]:      at knot//net.minecraft.world.entity.monster.EnderMan.setPersistentAngerTarget(EnderMan.java)

[Server thread/INFO]: [STDERR]: java.lang.NullPointerException: Cannot invoke "net.minecraft.world.entity.EntityReference.getEntity(net.minecraft.world.level.Level, java.lang.Class)" because "angryAt" is null
[Server thread/INFO]: [STDERR]:      at knot//net.minecraft.world.entity.monster.zombie.ZombifiedPiglin.handler$bio001$lockout$setAngryAt(ZombifiedPiglin.java:535)
[Server thread/INFO]: [STDERR]:      at knot//net.minecraft.world.entity.monster.zombie.ZombifiedPiglin.setPersistentAngerTarget(ZombifiedPiglin.java)